### PR TITLE
Fix spelling in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Design Tokens plugin for fimga](https://github.com/lukasoppermann/design-tokens/raw/main/_resources/Design%20Tokens%20Plugin%20Cover.png)
+![Design Tokens plugin for figma](https://github.com/lukasoppermann/design-tokens/raw/main/_resources/Design%20Tokens%20Plugin%20Cover.png)
 # Design Tokens#
 
 <a href="https://www.producthunt.com/posts/figma-design-tokens-2?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-figma-design-tokens-2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=273532&theme=light" alt="Figma Design Tokens - Export & convert design tokens or sync with github repo. | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
@@ -31,7 +31,7 @@ git clone https://github.com/lukasoppermann/design-token-transformer.git
 ## Design Tokens
 ### Naming
 ### Design tokens from Styles
-The plugin converts the styles you define in Fimga into design tokens, this includes `Text Styles`, `Color Styles`, `Grid Styles` and `Effect Styles`.
+The plugin converts the styles you define in Figma into design tokens, this includes `Text Styles`, `Color Styles`, `Grid Styles` and `Effect Styles`.
 
 Every property of a style will be converted to an individual token. For a `Text Styles` this may result in the following tokens (show as transformed css custom properties for readability).
 
@@ -68,7 +68,7 @@ If you wanted to create a custom spacer token for an `8px` space you would do th
 4. Run the plugin `Design Tokens > Export Design Tokens`
 
 ### Available properties
-To allow for maximum customizability I decided to provide all values that Fimga provides. Many are not applicable to for example `css` but may be usable in other languages.
+To allow for maximum customizability I decided to provide all values that Figma provides. Many are not applicable to for example `css` but may be usable in other languages.
 
 **Colors** are provided in `rgba` but can be converted using [Amazon style dictionary](https://amzn.github.io/style-dictionary/#/).
 


### PR DESCRIPTION
Awesome plugin! Just noticed some spelling errors while going over the Readme (fimga -> figma) 😅