### PR TITLE
Remove formatting when sending JSON to server

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -1382,7 +1382,7 @@
                 return getTokenJson_1.default(figmaData);
             }
             // get tokens as stringified json
-            return JSON.stringify(getTokenJson_1.default(figmaData), null, 2);
+            return JSON.stringify(getTokenJson_1.default(figmaData));
         };
         // ---------------------------------
         // EXPORT TO FILE

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const getJson = (figma: PluginAPI, stringify: boolean = true) => {
     return getTokenJson(figmaData)
   }
   // get tokens as stringified json
-  return JSON.stringify(getTokenJson(figmaData), null, 2)
+  return JSON.stringify(getTokenJson(figmaData))
 }
 // ---------------------------------
 // EXPORT TO FILE


### PR DESCRIPTION
Partially fix https://github.com/lukasoppermann/design-tokens/issues/67

When sending to server, the code to stringify the JSON is adding some space to format it; by removing this I was able to bring down the size of a payload by 45% in some scenarios.

This fix will not prevent a too big payload from being rejected by Github, but it'll allow the biggest usable payload (I don't know how we can further compress the JSON but happy to hear from others).

The JSON can be reformatted on the receiving end if needed.

Btw thanks for the plugin! ❤️