### PR TITLE
updated mime-type and extension selection

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,5 +19,19 @@ export default {
     fileId: 'fileId',
     settings: 'settings'
   },
-  exclusionPrefixDefault: ['_', '.']
+  exclusionPrefixDefault: ['_', '.'],
+  fileExtensions: [
+    {
+      label: '.tokens.json',
+      value: '.tokens.json'
+    },
+    {
+      label: '.tokens',
+      value: '.tokens'
+    },
+    {
+      label: '.json',
+      value: '.json'
+    }
+  ]
 }

--- a/src/config/defaultSettings.ts
+++ b/src/config/defaultSettings.ts
@@ -3,7 +3,7 @@ import { Settings } from '@typings/settings'
 
 export const defaultSettings: Settings = {
   filename: 'design-tokens',
-  extension: '.json',
+  extension: '.tokens.json',
   nameConversion: 'default',
   compression: false,
   urlJsonCompression: true,

--- a/src/ui/components/FileExportSettings.tsx
+++ b/src/ui/components/FileExportSettings.tsx
@@ -13,6 +13,7 @@ import { Info } from '@components/Info'
 import { Row } from '@components/Row'
 import { tokenTypes } from '@config/tokenTypes'
 import { commands } from '@config/commands'
+import config from '@config/config'
 
 const style = css`
   display: flex;
@@ -80,12 +81,7 @@ export const FileExportSettings = () => {
           defaultValue={settings.extension}
           onChange={({ value }) => updateSettings((draft: Settings) => { draft.extension = value as string })}
           placeholder='file extension'
-          options={[
-            {
-              label: '.json',
-              value: '.json'
-            }
-          ]}
+          options={config.fileExtensions}
         />
       </Row>
       <Title size='large' weight='bold'>Include types in export</Title>

--- a/src/ui/modules/downloadJson.ts
+++ b/src/ui/modules/downloadJson.ts
@@ -17,7 +17,7 @@ export const downloadJson = (parent, link: HTMLLinkElement, json: string) => {
   }
   // try to export tokens
   try {
-    link.href = `data:text/json;charset=utf-8,${encodeURIComponent(json)}`
+    link.href = `data:application/design-tokens+json;charset=utf-8,${encodeURIComponent(json)}`
     // Programmatically trigger a click on the anchor element
     link.click()
     // send success messgae


### PR DESCRIPTION
Allow users to choose between `.tokens.json`, `.tokens`, `.json` when exporting file.

Also change the mime type to `application/design-tokens+json`