### PR TITLE
added fontWeights & fontStyles for Typeface Söhne

### DIFF
--- a/src/extractor/extractFonts.ts
+++ b/src/extractor/extractFonts.ts
@@ -24,18 +24,27 @@ const fontWeights = {
   thin: 100,
   extralight: 200,
   ultralight: 200,
+  extraleicht: 200,
   light: 300,
+  leicht: 300,
   normal: 400,
   regular: 400,
+  buch: 400,
   medium: 500,
+  kraeftig: 500,
+  kräftig: 500,
   semibold: 600,
   demibold: 600,
+  halbfett: 600,
   bold: 700,
+  dreiviertelfett: 700,
   extrabold: 800,
   ultabold: 800,
+  fett: 800,
   black: 900,
   heavy: 900,
-  super: 900
+  super: 900,
+  extrafett: 900
 }
 
 const fontStretch = {
@@ -48,6 +57,7 @@ const fontStretch = {
 const fontStyles = {
   normal: 'normal',
   italic: 'italic',
+  kursiv: 'italic',
   oblique: 'oblique'
 }
 


### PR DESCRIPTION
Added font-weights and font-styles suiting the weight and style labeling of the typeface Söhne by KlimType-Foundry.

Based on this Issue ↓
https://github.com/lukasoppermann/design-tokens/issues/147#issuecomment-934240122