### PR TITLE
Added filename alias field in settings & export menus

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,7 +3,7 @@ export default {
   ui: {
     generalSettings: {
       width: 550,
-      height: 685
+      height: 745
     },
     export: {
       width: 550,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -7,7 +7,7 @@ export default {
     },
     export: {
       width: 550,
-      height: 420
+      height: 340
     },
     urlExport: {
       width: 550,

--- a/src/config/defaultSettings.ts
+++ b/src/config/defaultSettings.ts
@@ -2,7 +2,7 @@
 import { Settings } from '@typings/settings'
 
 export const defaultSettings: Settings = {
-  filename: '',
+  filename: 'design-tokens',
   extension: '.tokens.json',
   nameConversion: 'default',
   tokenFormat: 'standard',

--- a/src/config/defaultSettings.ts
+++ b/src/config/defaultSettings.ts
@@ -2,7 +2,7 @@
 import { Settings } from '@typings/settings'
 
 export const defaultSettings: Settings = {
-  filename: 'design-tokens',
+  filename: '',
   extension: '.tokens.json',
   nameConversion: 'default',
   tokenFormat: 'standard',

--- a/src/ui/components/FileExportSettings.tsx
+++ b/src/ui/components/FileExportSettings.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import { useContext, useRef } from 'react'
 import { Button } from '@components/Button'
 import { Checkbox } from '@components/Checkbox'
-import { Input } from '@components/Input'
-import { Select } from '@components/Select'
 import { Title } from '@components/Title'
 import { FigmaContext, SettingsContext, TokenContext } from '@ui/context'
 import { CancelButton } from './CancelButton'
@@ -17,16 +15,11 @@ import { Info } from '@components/Info'
 import { Row } from '@components/Row'
 import { tokenTypes } from '@config/tokenTypes'
 import { commands } from '@config/commands'
-import config from '@config/config'
 import { WebLink } from './WebLink'
 
 const style = css`
   display: flex;
   flex-direction: column;
-  .grid-2-col {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-  }
   .grid-3-col {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -36,7 +29,7 @@ const style = css`
 export const FileExportSettings = () => {
   const { settings, updateSettings } = useContext<{settings: Settings, updateSettings: any}>(SettingsContext)
   const { tokens, setTokens } = useContext(TokenContext)
-  const { figmaUIApi, figmaMetaData } = useContext(FigmaContext)
+  const { figmaUIApi } = useContext(FigmaContext)
   const downloadLinkRef = useRef()
 
   const handleFormSubmit = (event) => {
@@ -75,23 +68,6 @@ export const FileExportSettings = () => {
         />
         <Info width={240} label='Compression removes line breaks and whitespace from the json string' />
       </Row>
-      <h3>Filename<Info width={150} label='Alias used for the JSON file name' /></h3>
-      <div className='grid-2-col'>
-        <Input
-          type='text'
-          required
-          pattern='^[\w\d\s\[\]._-]+$'
-          placeholder={figmaMetaData.filename}
-          value={settings.filename}
-          onChange={value => updateSettings((draft: Settings) => { draft.filename = value })}
-        />
-        <Select
-          defaultValue={settings.extension}
-          onChange={({ value }) => updateSettings((draft: Settings) => { draft.extension = value as string })}
-          placeholder='file extension'
-          options={config.fileExtensions}
-        />
-      </div>
       <Title size='large' weight='bold'>Include types in export</Title>
       <div className='grid-3-col'>
         {Object.entries(tokenTypes)

--- a/src/ui/components/FileExportSettings.tsx
+++ b/src/ui/components/FileExportSettings.tsx
@@ -23,6 +23,10 @@ import { WebLink } from './WebLink'
 const style = css`
   display: flex;
   flex-direction: column;
+  .grid-2-col {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
   .grid-3-col {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -32,10 +36,11 @@ const style = css`
 export const FileExportSettings = () => {
   const { settings, updateSettings } = useContext<{settings: Settings, updateSettings: any}>(SettingsContext)
   const { tokens, setTokens } = useContext(TokenContext)
-  const { figmaUIApi } = useContext(FigmaContext)
+  const { figmaUIApi, figmaMetaData } = useContext(FigmaContext)
   const downloadLinkRef = useRef()
 
   const handleFormSubmit = (event) => {
+    event.preventDefault(); // Prevent form submit triggering navigation
     const exportSettingsForm = event.target
     if (exportSettingsForm.checkValidity() === true) {
       const { accessToken, ...pluginSettings } = settings
@@ -70,12 +75,13 @@ export const FileExportSettings = () => {
         />
         <Info width={240} label='Compression removes line breaks and whitespace from the json string' />
       </Row>
-      <h3>Filename</h3>
-      <Row fill>
+      <h3>Filename<Info width={150} label='Alias used for the JSON file name' /></h3>
+      <div className='grid-2-col'>
         <Input
           type='text'
-          pattern='^[\w\-\.\+@]+$'
-          placeholder='design-tokens'
+          required
+          pattern='^[\w\d\s\[\]._-]+$'
+          placeholder={figmaMetaData.filename}
           value={settings.filename}
           onChange={value => updateSettings((draft: Settings) => { draft.filename = value })}
         />
@@ -85,7 +91,7 @@ export const FileExportSettings = () => {
           placeholder='file extension'
           options={config.fileExtensions}
         />
-      </Row>
+      </div>
       <Title size='large' weight='bold'>Include types in export</Title>
       <div className='grid-3-col'>
         {Object.entries(tokenTypes)

--- a/src/ui/components/GeneralSettings.tsx
+++ b/src/ui/components/GeneralSettings.tsx
@@ -77,7 +77,7 @@ export const GeneralSettings = () => {
         />
         <Info width={240} label='The token type (e.g. "color" or "font") will be added to the name e.g. "color/light/bg".' />
       </Row>
-      <Title size='small' weight='bold' level="h3">
+      <Title size='small' weight='bold'>
         Filename
         <Info width={160} label='The file name used when exporting the tokens' />
       </Title>

--- a/src/ui/components/GeneralSettings.tsx
+++ b/src/ui/components/GeneralSettings.tsx
@@ -11,6 +11,7 @@ import { useContext, useState } from 'react'
 import { FigmaContext, SettingsContext } from '@ui/context'
 import { css } from '@emotion/css'
 import { commands } from '@config/commands'
+import config from '@config/config'
 import { Footer } from '@components/Footer'
 import { nameConversionType, Settings, tokenFormatType } from '@typings/settings'
 import { Row } from '@components/Row'
@@ -41,10 +42,11 @@ const isStyle = (key: string): boolean => ['color', 'gradient', 'grid', 'effect'
 
 export const GeneralSettings = () => {
   const [isStandard, setStandard] = useState(false)
-  const { figmaUIApi } = useContext(FigmaContext)
+  const { figmaUIApi, figmaMetaData } = useContext(FigmaContext)
   const { settings, updateSettings } = useContext<{settings: Settings, updateSettings: any}>(SettingsContext)
 
   const handleFormSubmit = (event) => {
+    event.preventDefault(); // Prevent form submit triggering navigation
     const settingsForm = event.target
     if (settingsForm.checkValidity() === true) {
       const { accessToken, ...pluginSettings } = settings
@@ -75,6 +77,26 @@ export const GeneralSettings = () => {
         />
         <Info width={240} label='The token type (e.g. "color" or "font") will be added to the name e.g. "color/light/bg".' />
       </Row>
+      <Title size='small' weight='bold' level="h3">
+        Filename
+        <Info width={160} label='The file name used when exporting the tokens' />
+      </Title>
+      <div className='grid-2-col'>
+        <Input
+          type='text'
+          required
+          pattern='^[\w\d\s\[\]._-]+$'
+          placeholder={figmaMetaData.filename}
+          value={settings.filename}
+          onChange={value => updateSettings((draft: Settings) => { draft.filename = value })}
+        />
+        <Select
+          defaultValue={settings.extension}
+          onChange={({ value }) => updateSettings((draft: Settings) => { draft.extension = value as string })}
+          placeholder='file extension'
+          options={config.fileExtensions}
+        />
+      </div>
       <Separator />
       <div className='grid-2-col'>
         <div>

--- a/src/ui/components/UrlExportSettings.tsx
+++ b/src/ui/components/UrlExportSettings.tsx
@@ -17,17 +17,12 @@ import { urlExport } from '../modules/urlExport'
 import { urlExportRequestBody, urlExportSettings } from '@typings/urlExportData'
 import { PluginMessage } from '@typings/pluginEvent'
 import { commands } from '@config/commands'
-import config from '@config/config'
 import { stringifyJson } from '@src/utilities/stringifyJson'
 import { WebLink } from './WebLink'
 
 const style = css`
   display: flex;
   flex-direction: column;
-  .grid-2-col {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-  }
   .grid-3-col {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -37,7 +32,7 @@ const style = css`
 export const UrlExportSettings = () => {
   const { settings, updateSettings } = useContext<{settings: Settings, updateSettings: any}>(SettingsContext)
   const { tokens, setTokens } = useContext(TokenContext)
-  const { figmaUIApi, figmaMetaData } = useContext(FigmaContext)
+  const { figmaUIApi } = useContext(FigmaContext)
 
   const handleFormSubmit = (event) => {
     event.preventDefault(); // Prevent form submit triggering navigation
@@ -87,22 +82,6 @@ export const UrlExportSettings = () => {
         />
         <Info width={240} label='Compression removes line breaks and whitespace from the json string' />
       </Row>
-      <h3>Filename alias<Info width={150} label='Filename used for the tokens in the POST request' /></h3>
-      <div className='grid-2-col'>
-        <Input
-          type='text'
-          pattern='^[\w\d\s\[\]._-]+$'
-          placeholder={figmaMetaData.filename}
-          value={settings.filename}
-          onChange={value => updateSettings((draft: Settings) => { draft.filename = value })}
-        />
-        <Select
-          defaultValue={settings.extension}
-          onChange={({ value }) => updateSettings((draft: Settings) => { draft.extension = value as string })}
-          placeholder='file extension'
-          options={config.fileExtensions}
-        />
-      </div>
       <Title size='xlarge' weight='bold'>Server settings</Title>
       <h3>Event type<Info width={150} label='"event_type" property in post request' /></h3>
       <Row fill>

--- a/src/ui/ui.tsx
+++ b/src/ui/ui.tsx
@@ -41,7 +41,10 @@ const PluginUi = () => {
     const { command, payload } = event.data.pluginMessage as {command: PluginCommands, payload: any}
     // set settings
     if ([commands.urlExport, commands.export, commands.generalSettings].includes(command)) {
-      updateSettings(payload.settings)
+      updateSettings({
+        ...payload.settings,
+        filename: payload.settings.filename || payload.metadata.filename
+      })
       setVersionDifference(payload.versionDifference)
       setFigmaMetaData(payload.metadata)
       setTokens(payload.data)


### PR DESCRIPTION
Added `Filename` fields in the `Settings` and `URL Export` screens, next to the existing one in `Export to file`.

The reason for adding it is more to accommodate an use case that we're currently having in Nutanix when exporting to URL, where UX wants to have friendly names on the Figma files and the ability to (re)name these files as they please, while engineering need a bit of a more standardized file naming pattern, especially when automating with GH Actions.

As an example, see the table below

| Figma file name                       | Alias name (sent to GH Actions) |
|---------------------------------------|---------------------------------|
| Core Design Tokens - Light            | light.core.tokens.json          |
| Core Design Tokens - Dark             | dark.core.tokens.json           |
| Core Design Tokens - Theme X          | theme-x.core.tokens.json        |
| Kittens team super awesome UX [Light] | light.kittens-team.tokens.json  |
| ...                                   | ...                             |

Please let me know if I need to do any further improvements and/or add test in order to accept this contribution.