### PR TITLE
Added support for transparent fills

### DIFF
--- a/src/extractor/extractColors.ts
+++ b/src/extractor/extractColors.ts
@@ -9,6 +9,13 @@ import { tokenCategoryType } from '@typings/tokenCategory'
 import { tokenExportKeyType } from '@typings/tokenExportKey'
 import config from '@config/config'
 
+const transparentFill: fillValuesType = {
+  fill: {
+    value: {r: 0, g: 0, b: 0, a: 0},
+    type: 'color'
+  }
+}
+
 const parseDescription = (description: string = '', aliasArray: string[]) => {
   aliasArray = !aliasArray || aliasArray.filter(i => i).length === 0 ? ['Ref:'] : aliasArray
   const regex = new RegExp('(' + aliasArray.join('|').toLowerCase() + ')' + ':?\\s')
@@ -39,7 +46,7 @@ const gradientType = {
   GRADIENT_DIAMOND: 'diamond'
 }
 
-const isGradient = (paint): boolean => ['GRADIENT_LINEAR', 'GRADIENT_RADIAL', 'GRADIENT_ANGULAR', 'GRADIENT_DIAMOND'].includes(paint.type)
+const isGradient = (paint): boolean => ['GRADIENT_LINEAR', 'GRADIENT_RADIAL', 'GRADIENT_ANGULAR', 'GRADIENT_DIAMOND'].includes(paint?.type)
 
 const rotationFromMatrix = ([[x1, y1], [x2, y2]]) => {
   // https://stackoverflow.com/questions/24909586/find-rotation-angle-for-affine-transform
@@ -92,31 +99,37 @@ const extractFills = (paint): fillValuesType | gradientValuesType => {
 const extractColors: extractorInterface = (tokenNodes: PaintStyleObject[], prefixArray: {color: string[], gradient: string[], alias: string[]}): colorPropertyInterface[] => {
   // get all paint styles
   return tokenNodes
-  // remove images fills from tokens
-    .map(node => {
-      node.paints = node.paints.filter(paint => paint.type !== 'IMAGE')
-      return node
-    })
-    // remove tokens with no fill
-    .filter(node => node.paints.length > 0)
-    // transform style
-    .map(node => {
+    .reduce((previousValue, node) => {
+      // ignore image-only fills
+      const paintsAfterImageFilter = node.paints.filter(paint => paint.type !== 'IMAGE');
+      if(node.paints.length && paintsAfterImageFilter.length === 0) {
+        return previousValue;
+      }
+      // remove images fills from tokens
+      node.paints = paintsAfterImageFilter;
+
       const { alias, description } = parseDescription(node.description, prefixArray.alias)
-      return {
-        name: `${isGradient(node.paints[0]) ? prefixArray.gradient[0] : prefixArray.color[0]}/${node.name}`,
-        category: isGradient(node.paints[0]) ? 'gradient' : 'color' as tokenCategoryType,
-        exportKey: (isGradient(node.paints[0]) ? tokenTypes.gradient.key : tokenTypes.color.key) as tokenExportKeyType,
-        description: description,
-        values: node.paints.map(paint => extractFills(paint)),
-        extensions: {
-          [config.key.extensionPluginData]: {
-            [config.key.extensionFigmaStyleId]: node.id,
-            exportKey: (isGradient(node.paints[0]) ? tokenTypes.gradient.key : tokenTypes.color.key) as tokenExportKeyType,
-            ...(addAlias(alias))
+      const nodeIsGradient = isGradient(node.paints[0]);
+      const values = node.paints.length ? node.paints.map(paint => extractFills(paint)) : [transparentFill];
+
+      return [
+        ...previousValue,
+        {
+          name: `${nodeIsGradient ? prefixArray.gradient[0] : prefixArray.color[0]}/${node.name}`,
+          category: nodeIsGradient ? 'gradient' : 'color' as tokenCategoryType,
+          exportKey: (nodeIsGradient ? tokenTypes.gradient.key : tokenTypes.color.key) as tokenExportKeyType,
+          description: description,
+          values,
+          extensions: {
+            [config.key.extensionPluginData]: {
+              [config.key.extensionFigmaStyleId]: node.id,
+              exportKey: (nodeIsGradient ? tokenTypes.gradient.key : tokenTypes.color.key) as tokenExportKeyType,
+              ...(addAlias(alias))
+            }
           }
         }
-      }
-    })
+      ];
+    }, []);
 }
 
 export default extractColors

--- a/src/utilities/convertColor.ts
+++ b/src/utilities/convertColor.ts
@@ -11,12 +11,12 @@ export const roundRgba = (rgba: {
   r: roundWithDecimals(rgba.r * 255, 0),
   g: roundWithDecimals(rgba.g * 255, 0),
   b: roundWithDecimals(rgba.b * 255, 0),
-  a: roundWithDecimals(opacity || rgba.a || 1)
+  a: roundWithDecimals(opacity ?? rgba.a ?? 1)
 })
 
 export const convertPaintToRgba = (paint): ColorRgba => {
   if (paint.type === 'SOLID' && paint.visible === true) {
-    return roundRgba(paint.color, (paint.opacity || null))
+    return roundRgba(paint.color, paint.opacity)
   }
   return null
 }

--- a/tests/unit/data/paintStyleObjects.data.ts
+++ b/tests/unit/data/paintStyleObjects.data.ts
@@ -37,6 +37,32 @@ export const paintStyles = [
     ]
   },
   {
+    name: 'transparent1',
+    description: 'i have no paints',
+    id: 1,
+    paints: [
+
+    ]
+  },
+  {
+    name: 'transparent2',
+    description: 'i have opacity 0',
+    id: 1,
+    paints: [
+      {
+        blendMode: 'NORMAL',
+        type: 'SOLID',
+        color: {
+          r: 1,
+          g: 1,
+          b: 1
+        },
+        opacity: 0,
+        visible: true
+      }
+    ]
+  },
+  {
     name: 'multi',
     description: 'multiple fills',
     id: 2,
@@ -204,6 +230,32 @@ export const paintStyleObjects = [
           b: 0.7299998998641968
         },
         opacity: 0.5,
+        visible: true
+      }
+    ]
+  },
+  {
+    name: 'transparent1',
+    description: 'i have no paints',
+    id: 1,
+    paints: [
+
+    ]
+  },
+  {
+    name: 'transparent2',
+    description: 'i have opacity 0',
+    id: 1,
+    paints: [
+      {
+        blendMode: 'NORMAL',
+        type: 'SOLID',
+        color: {
+          r: 1,
+          g: 1,
+          b: 1
+        },
+        opacity: 0,
         visible: true
       }
     ]

--- a/tests/unit/extractColors.test.ts
+++ b/tests/unit/extractColors.test.ts
@@ -54,6 +54,52 @@ describe('extracting color fills', () => {
       {
         category: 'color',
         exportKey: 'color',
+        description: 'i have no paints',
+        name: 'colors/transparent1',
+        extensions: {
+          'org.lukasoppermann.figmaDesignTokens': {
+            exportKey: 'color',
+            styleId: 1
+          }
+        },
+        values: [{
+          fill: {
+            type: 'color',
+            value: {
+              a: 0,
+              b: 0,
+              g: 0,
+              r: 0
+            }
+          }
+        }]
+      },
+      {
+        category: 'color',
+        exportKey: 'color',
+        description: 'i have opacity 0',
+        name: 'colors/transparent2',
+        extensions: {
+          'org.lukasoppermann.figmaDesignTokens': {
+            exportKey: 'color',
+            styleId: 1
+          }
+        },
+        values: [{
+          fill: {
+            type: 'color',
+            value: {
+              a: 0,
+              b: 255,
+              g: 255,
+              r: 255
+            }
+          }
+        }]
+      },
+      {
+        category: 'color',
+        exportKey: 'color',
         description: 'multiple fills',
         name: 'colors/multi',
         extensions: {


### PR DESCRIPTION
Solves #179

TL;DR: Allows the plugin to handle Color Styles where there is no property (fill) or the it has opacity 0. For both cases, the plugin will now export a Hex8 with `00` at the end.

Previously, due to defaults, fills with opacity 0 were exported with `FF` opacity. Empty fills were completely discarded.