### PR TITLE
Add custom opacity token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ To create opacity tokens, do the following:
 1. Create a new `Frame` called `_tokens/opacities`
 2. Create a new `Main Component`
 3. Set the desired `Pass through` value (ie. 30%)
-4. Name it `opacity/input-disabled` for example
+4. Give it a fitting name, e.g. `opacity/input-disabled`
 
 After exporting it, if you convert it to CSS, the resulting token will look like this:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The **Design Tokens** plugin for figma allows you to export design tokens into a
     - [Spacing token](#spacing)
     - [Breakpoints token](#breakpoints)
     - [Motion token](#motion)
+    - [Opacity token](#opacity)
   - [Available properties](#available-properties)
 - [Settings](#settings)
   - [File Export Settings](#file-export-settings)  

--- a/README.md
+++ b/README.md
@@ -231,6 +231,20 @@ When exporting your tokens you will now get a set of properties for this motion 
   --motion-move-in-direction: left;
 ```
 
+#### Opacity
+To create opacity tokens, do the following:
+
+1. Create a new `Frame` called `_tokens/opacities`
+2. Create a new `Main Component`
+3. Set the desired `Pass through` value (ie. 30%)
+4. Name it `opacity/input-disabled` for example
+
+After exporting it, if you convert it to CSS, the resulting token will look like this:
+
+```css
+--opacity-input-disabled: 0.3;
+```
+
 ### Available properties
 To allow for maximum customizability I decided to provide all values that Figma provides. Many are not applicable to for example `css` but may be usable in other languages.
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -7,7 +7,7 @@ export default {
     },
     export: {
       width: 550,
-      height: 340
+      height: 356
     },
     urlExport: {
       width: 550,

--- a/src/config/defaultSettings.ts
+++ b/src/config/defaultSettings.ts
@@ -31,7 +31,8 @@ export const defaultSettings: Settings = {
     radius: 'radius, radii',
     size: 'size, sizes',
     spacing: 'spacing',
-    motion: 'motion'
+    motion: 'motion',
+    opacity: 'opacity, opacities'
   },
   exports: {
     color: true,
@@ -45,6 +46,7 @@ export const defaultSettings: Settings = {
     radius: true,
     size: true,
     spacing: true,
-    motion: true
+    motion: true,
+    opacity: true
   }
 }

--- a/src/config/tokenTypes.ts
+++ b/src/config/tokenTypes.ts
@@ -48,5 +48,9 @@ export const tokenTypes = {
   motion: {
     label: 'Motion',
     key: 'motion'
+  },
+  opacity: {
+    label: 'Opacity',
+    key: 'opacity'
   }
 }

--- a/src/extractor/extractOpacities.ts
+++ b/src/extractor/extractOpacities.ts
@@ -1,0 +1,33 @@
+import extractorInterface from '@typings/extractorInterface'
+import { opacityPropertyInterface } from '@typings/propertyObject'
+import { customTokenNode } from '@typings/tokenNodeTypes'
+import { UnitTypePixel, PropertyType } from '@typings/valueTypes'
+import { tokenTypes } from '@config/tokenTypes'
+import roundWithDecimals from '../utilities/roundWithDecimals'
+import { filterByPrefix } from './extractUtilities'
+import { tokenExportKeyType } from '@typings/tokenExportKey'
+import { tokenCategoryType } from '@typings/tokenCategory'
+import config from '@config/config'
+
+const extractOpacities: extractorInterface = (tokenNodes: customTokenNode[], prefixArray: string[]): opacityPropertyInterface[] => {
+  // return as object
+  return tokenNodes.filter(filterByPrefix(prefixArray)).map(node => ({
+    name: node.name,
+    category: 'opacity' as tokenCategoryType,
+    exportKey: tokenTypes.opacity.key as tokenExportKeyType,
+    description: node.description || null,
+    values: {
+      opacity: {
+        value: roundWithDecimals(node.opacity, 2),
+        type: 'number' as PropertyType
+      }
+    },
+    extensions: {
+      [config.key.extensionPluginData]: {
+        exportKey: tokenTypes.opacity.key as tokenExportKeyType
+      }
+    }
+  }))
+}
+
+export default extractOpacities

--- a/src/extractor/extractOpacities.ts
+++ b/src/extractor/extractOpacities.ts
@@ -1,7 +1,7 @@
 import extractorInterface from '@typings/extractorInterface'
 import { opacityPropertyInterface } from '@typings/propertyObject'
 import { customTokenNode } from '@typings/tokenNodeTypes'
-import { UnitTypePixel, PropertyType } from '@typings/valueTypes'
+import { PropertyType } from '@typings/valueTypes'
 import { tokenTypes } from '@config/tokenTypes'
 import roundWithDecimals from '../utilities/roundWithDecimals'
 import { filterByPrefix } from './extractUtilities'

--- a/src/transformer/originalFormatTransformer.ts
+++ b/src/transformer/originalFormatTransformer.ts
@@ -177,7 +177,8 @@ const valueTransformer: {} | undefined = {
   breakpoint: sizeValueTransformer,
   radius: defaultValueTransformer,
   spacing: defaultValueTransformer,
-  motion: motionValueTransformer
+  motion: motionValueTransformer,
+  opacity: defaultValueTransformer // TOOD
 }
 
 const transformer = (token: internalTokenInterface): OriginalFormatTokenInterface => {

--- a/src/transformer/originalFormatTransformer.ts
+++ b/src/transformer/originalFormatTransformer.ts
@@ -166,7 +166,7 @@ const motionValueTransformer = (values) => {
   }
 }
 
-const opacityValuesTransformer = ({ opacity }) => ({
+const opacityValueTransformer = ({ opacity }) => ({
   value: opacity.value,
   type: opacity.type
 })
@@ -183,7 +183,7 @@ const valueTransformer: {} | undefined = {
   radius: defaultValueTransformer,
   spacing: defaultValueTransformer,
   motion: motionValueTransformer,
-  opacity: opacityValuesTransformer
+  opacity: opacityValueTransformer
 }
 
 const transformer = (token: internalTokenInterface): OriginalFormatTokenInterface => {

--- a/src/transformer/originalFormatTransformer.ts
+++ b/src/transformer/originalFormatTransformer.ts
@@ -166,6 +166,11 @@ const motionValueTransformer = (values) => {
   }
 }
 
+const opacityValuesTransformer = ({ opacity }) => ({
+  value: opacity.value,
+  type: opacity.type
+})
+
 const valueTransformer: {} | undefined = {
   size: sizeValueTransformer,
   color: defaultValueTransformer,
@@ -178,7 +183,7 @@ const valueTransformer: {} | undefined = {
   radius: defaultValueTransformer,
   spacing: defaultValueTransformer,
   motion: motionValueTransformer,
-  opacity: defaultValueTransformer // TOOD
+  opacity: opacityValuesTransformer // TOOD
 }
 
 const transformer = (token: internalTokenInterface): OriginalFormatTokenInterface => {

--- a/src/transformer/originalFormatTransformer.ts
+++ b/src/transformer/originalFormatTransformer.ts
@@ -183,7 +183,7 @@ const valueTransformer: {} | undefined = {
   radius: defaultValueTransformer,
   spacing: defaultValueTransformer,
   motion: motionValueTransformer,
-  opacity: opacityValuesTransformer // TOOD
+  opacity: opacityValuesTransformer
 }
 
 const transformer = (token: internalTokenInterface): OriginalFormatTokenInterface => {

--- a/src/transformer/standardTransformer.ts
+++ b/src/transformer/standardTransformer.ts
@@ -30,7 +30,7 @@ const widthToDimensionTransformer = ({ values }): StandardTokenDataInterface => 
   type: 'dimension' as StandardTokenTypes
 })
 
-const opacityTransformer = ({ values }): StandardTokenDataInterface => ({
+const opacityValueTransformer = ({ values }): StandardTokenDataInterface => ({
   value: values.opacity.value,
   type: 'custom-opacity' as StandardTokenTypes
 })
@@ -251,7 +251,7 @@ const valueTransformer = {
   radius: radiusValueTransformer,
   spacing: spacingValueTransformer,
   motion: motionValueTransformer,
-  opacity: opacityTransformer
+  opacity: opacityValueTransformer
 }
 
 const transformTokens = (token: internalTokenInterface): StandardTokenDataInterface | StandardTokenGroup => valueTransformer[token.category](token)

--- a/src/transformer/standardTransformer.ts
+++ b/src/transformer/standardTransformer.ts
@@ -30,6 +30,11 @@ const widthToDimensionTransformer = ({ values }): StandardTokenDataInterface => 
   type: 'dimension' as StandardTokenTypes
 })
 
+const opacityTransformer = ({ values }): StandardTokenDataInterface => ({
+  value: values.opacity.value,
+  type: 'custom-opacity' as StandardTokenTypes
+})
+
 const radiusValueTransformer = ({ values }): StandardTokenDataInterface => ({
   type: 'custom-radius' as StandardTokenTypes,
   value: {
@@ -199,7 +204,7 @@ const shadowValueTransformer = (value): StandardTokenDataInterface => ({
     color: rgbaObjectToHex8(value.color.value),
     offsetX: value.offset.x.value,
     offsetY: value.offset.y.value,
-    spread: value.spread.value
+    spread: value.spread.value,
   }
 })
 
@@ -245,7 +250,8 @@ const valueTransformer = {
   breakpoint: widthToDimensionTransformer,
   radius: radiusValueTransformer,
   spacing: spacingValueTransformer,
-  motion: motionValueTransformer
+  motion: motionValueTransformer,
+  opacity: opacityTransformer
 }
 
 const transformTokens = (token: internalTokenInterface): StandardTokenDataInterface | StandardTokenGroup => valueTransformer[token.category](token)

--- a/src/transformer/standardTransformer.ts
+++ b/src/transformer/standardTransformer.ts
@@ -204,7 +204,7 @@ const shadowValueTransformer = (value): StandardTokenDataInterface => ({
     color: rgbaObjectToHex8(value.color.value),
     offsetX: value.offset.x.value,
     offsetY: value.offset.y.value,
-    spread: value.spread.value,
+    spread: value.spread.value
   }
 })
 

--- a/src/utilities/extractTokenNodeValues.ts
+++ b/src/utilities/extractTokenNodeValues.ts
@@ -43,7 +43,8 @@ const extractTokenNodeValues = (node: ComponentNode | RectangleNode | FrameNode)
   // @ts-ignore
   paddingBottom: node.paddingBottom || 0,
   // @ts-ignore
-  paddingLeft: node.paddingLeft || 0
+  paddingLeft: node.paddingLeft || 0,
+  opacity: node.opacity
 })
 
 export default extractTokenNodeValues

--- a/src/utilities/extractTokenNodeValues.ts
+++ b/src/utilities/extractTokenNodeValues.ts
@@ -44,7 +44,7 @@ const extractTokenNodeValues = (node: ComponentNode | RectangleNode | FrameNode)
   paddingBottom: node.paddingBottom || 0,
   // @ts-ignore
   paddingLeft: node.paddingLeft || 0,
-  opacity: node.opacity
+  opacity: node.opacity ?? 1
 })
 
 export default extractTokenNodeValues

--- a/src/utilities/getTokenJson.ts
+++ b/src/utilities/getTokenJson.ts
@@ -8,6 +8,7 @@ import extractSpacing from '../extractor/extractSpacing'
 import extractBorders from '../extractor/extractBorders'
 import extractRadii from '../extractor/extractRadii'
 import extractBreakpoints from '../extractor/extractBreakpoints'
+import extractOpacities from '../extractor/extractOpacities'
 import { figmaDataType } from '@typings/figmaDataType'
 import buildFigmaData from './buildFigmaData'
 import { Settings } from '@typings/settings'
@@ -24,6 +25,7 @@ export const exportRawTokenArray = (figma: PluginAPI, settings: Settings) => {
     ...extractBorders(figmaData.tokenFrames, getPrefixArray(settings.prefix.border)),
     ...extractRadii(figmaData.tokenFrames, getPrefixArray(settings.prefix.radius)),
     ...extractMotion(figmaData.tokenFrames, getPrefixArray(settings.prefix.motion)),
+    ...extractOpacities(figmaData.tokenFrames, getPrefixArray(settings.prefix.opacity)),
     ...extractColors(figmaData.paintStyles, { color: getPrefixArray(settings.prefix.color), gradient: getPrefixArray(settings.prefix.gradient), alias: getPrefixArray(settings.alias) }),
     ...extractGrids(figmaData.gridStyles, getPrefixArray(settings.prefix.grid)),
     ...extractFonts(figmaData.textStyles, getPrefixArray(settings.prefix.font)),

--- a/tests/files/original-tokens.json
+++ b/tests/files/original-tokens.json
@@ -117,6 +117,16 @@
       "unit": "pixel"
     }
   },
+  "opacities": {
+    "button-disabled": {
+      "category": "opacity",
+      "comment": "an opacity description",
+      "exportKey": "opacity",
+      "name": "disabled button opacity",
+      "type": "number",
+      "value": 0.3
+    }
+  },
   "spacing": {
     "10": {
       "category": "spacing",

--- a/tests/files/standard-tokens.json
+++ b/tests/files/standard-tokens.json
@@ -163,6 +163,18 @@
       }
     }
   },
+  "opacities": {
+    "button-disabled": {
+      "description": null,
+      "value": 0.3,
+      "type": "custom-opacity",
+      "extensions": {
+        "org.lukasoppermann.figmaDesignTokens": {
+          "exportKey": "opacity"
+        }
+      }
+    }
+  },
   "spacing": {
     "10": {
       "description": null,

--- a/tests/integration/data/cssOutput.data.ts
+++ b/tests/integration/data/cssOutput.data.ts
@@ -16,6 +16,7 @@ export default
   --breakpoints-lg: 1280;
   --breakpoints-sm: 768;
   --breakpoints-md: 1024;
+  --opacities-button-disabled: 0.3; /* an opacity description */
   --spacing-10-top: 10;
   --spacing-10-right: 10;
   --spacing-10-bottom: 10;

--- a/tests/integration/data/cssStandardOutput.data.ts
+++ b/tests/integration/data/cssStandardOutput.data.ts
@@ -16,6 +16,7 @@ export default
   --breakpoints-lg: 1280px;
   --breakpoints-sm: 768px;
   --breakpoints-md: 1024px;
+  --opacities-button-disabled: 0.3;
   --spacing-10: 10px;
   --spacing-mixed: 10px 20px 30px 20px;
   --spacing-top: 10px 0px 0px 0px;

--- a/tests/integration/data/jsonOriginalFormat.data.ts
+++ b/tests/integration/data/jsonOriginalFormat.data.ts
@@ -597,6 +597,12 @@ export default {
       value: 768
     }
   },
+  opacities: {
+    'button-disabled': {
+      value: 0.3,
+      type: 'number'
+    }
+  },
   color: {
     colors: {
       'multiple fills': {

--- a/tests/integration/data/original.variables.css
+++ b/tests/integration/data/original.variables.css
@@ -15,6 +15,7 @@
   --breakpoints-lg: 1280;
   --breakpoints-sm: 768;
   --breakpoints-md: 1024;
+  --opacities-button-disabled: 0.3; /* an opacity description */
   --spacing-10-top: 10;
   --spacing-10-right: 10;
   --spacing-10-bottom: 10;

--- a/tests/integration/data/standard.variables.css
+++ b/tests/integration/data/standard.variables.css
@@ -15,6 +15,7 @@
   --breakpoints-lg: 1280px;
   --breakpoints-sm: 768px;
   --breakpoints-md: 1024px;
+  --opacities-button-disabled: 0.3;
   --spacing-10: 10px;
   --spacing-mixed: 10px 20px 30px 20px;
   --spacing-top: 10px 0px 0px 0px;

--- a/tests/unit/data/extractedFigmaTokens.data.ts
+++ b/tests/unit/data/extractedFigmaTokens.data.ts
@@ -54,6 +54,24 @@ export const extractedFigmaTokens = {
       }
     }
   },
+  opacity: {
+    name: 'disabled button opacity',
+    category: 'opacity' as tokenCategoryType,
+    exportKey: 'opacity' as tokenExportKeyType,
+    description: 'an opacity description',
+    values: {
+      opacity: {
+        type: 'number',
+        value: 0.3
+      }
+    },
+    type: 'custom-opacity',
+    extensions: {
+      'org.lukasoppermann.figmaDesignTokens': {
+        exportKey: 'opacity'
+      }
+    }
+  },
   /**
    * spacing
    */

--- a/tests/unit/data/extractedFigmaTokens.data.ts
+++ b/tests/unit/data/extractedFigmaTokens.data.ts
@@ -65,7 +65,6 @@ export const extractedFigmaTokens = {
         value: 0.3
       }
     },
-    type: 'custom-opacity',
     extensions: {
       'org.lukasoppermann.figmaDesignTokens': {
         exportKey: 'opacity'

--- a/tests/unit/data/transformedOriginalFormatTokens.data.ts
+++ b/tests/unit/data/transformedOriginalFormatTokens.data.ts
@@ -1,4 +1,4 @@
-// Tokens transformed to the "originalFormat"
+// Tokens transformed to the 'originalFormat'
 export const transformedOriginalTokens = {
   /**
    * size
@@ -23,6 +23,14 @@ export const transformedOriginalTokens = {
     type: 'number',
     unit: 'pixel',
     value: 1024
+  },
+  opacity: {
+    category: 'opacity',
+    comment: 'an opacity description',
+    exportKey: 'opacity',
+    name: 'disabled button opacity',
+    type: 'number',
+    value: 0.3,
   },
   /**
    * spacing

--- a/tests/unit/data/transformedStandardTokens.data.ts
+++ b/tests/unit/data/transformedStandardTokens.data.ts
@@ -30,6 +30,20 @@ export const transformedStandardTokens = {
     }
   },
   /**
+   * opacity
+   */
+  opacity: {
+    name: 'disabled button opacity',
+    value: 0.3,
+    description: 'an opacity description',
+    type: 'custom-opacity',
+    extensions: {
+      'org.lukasoppermann.figmaDesignTokens': {
+        exportKey: 'opacity'
+      }
+    }
+  },
+  /**
    * spacing
    */
   spacing: {

--- a/tests/unit/exportRawTokenArray.test.ts
+++ b/tests/unit/exportRawTokenArray.test.ts
@@ -10,6 +10,7 @@ import extractBorders from '../../src/extractor/extractBorders'
 import extractRadii from '../../src/extractor/extractRadii'
 import extractMotion from '../../src/extractor/extractMotion'
 import extractBreakpoints from '../../src/extractor/extractBreakpoints'
+import extractOpacities from '../../src/extractor/extractOpacities'
 import buildFigmaData from '../../src/utilities/buildFigmaData'
 import { defaultSettings } from '../../src/config/defaultSettings'
 jest.mock('../../src/extractor/extractFonts', () => jest.fn())
@@ -22,6 +23,7 @@ jest.mock('../../src/extractor/extractBorders', () => jest.fn())
 jest.mock('../../src/extractor/extractRadii', () => jest.fn())
 jest.mock('../../src/extractor/extractMotion', () => jest.fn())
 jest.mock('../../src/extractor/extractBreakpoints', () => jest.fn())
+jest.mock('../../src/extractor/extractOpacities', () => jest.fn())
 jest.mock('../../src/utilities/buildFigmaData', () => jest.fn())
 
 describe('exportRawTokenArray', () => {
@@ -48,6 +50,8 @@ describe('exportRawTokenArray', () => {
     extractMotion.mockImplementation(() => [])
     // @ts-ignore
     extractBreakpoints.mockImplementation(() => [])
+    // @ts-ignore
+    extractOpacities.mockImplementation(() => [])
     // @ts-ignore
     expect(exportRawTokenArray('', defaultSettings)).toStrictEqual([])
   })
@@ -118,10 +122,28 @@ describe('exportRawTokenArray', () => {
         values: 'this would be values'
       }
     ])
+    // @ts-ignore
+    extractBreakpoints.mockImplementation(() => [
+      {
+        name: 'breakpoints/basic',
+        values: 'this would be values'
+      }
+    ])
+    // @ts-ignore
+    extractOpacities.mockImplementation(() => [
+      {
+        name: 'opacities/basic',
+        values: 'this would be values'
+      }
+    ])
 
     const output = [
       {
         name: 'sizes/basic',
+        values: 'this would be values'
+      },
+      {
+        name: 'breakpoints/basic',
         values: 'this would be values'
       },
       {
@@ -138,6 +160,10 @@ describe('exportRawTokenArray', () => {
       },
       {
         name: 'motion/basic',
+        values: 'this would be values'
+      },
+      {
+        name: 'opacities/basic',
         values: 'this would be values'
       },
       {

--- a/tests/unit/extractOpacitites.test.ts
+++ b/tests/unit/extractOpacitites.test.ts
@@ -1,0 +1,36 @@
+import extractOpacities from '../../src/extractor/extractOpacities'
+import { customTokenNode } from './data/customTokenNode.data'
+
+describe('extracting opacities', () => {
+  const nodeArray = [
+    {
+      ...customTokenNode,
+      ...{
+        name: 'opacities/button-disabled',
+        description: 'the opacity of disabled buttons',
+        opacity: 0.3
+      }
+    }
+  ]
+
+  test('extracting only the token with correct name from customTokenNodesArray', () => {
+    expect(extractOpacities(nodeArray, ['opacities'])).toStrictEqual([{
+      category: 'opacity',
+      description: 'the opacity of disabled buttons',
+      exportKey: 'opacity',
+      name: 'opacities/button-disabled',
+      values: {
+        opacity: {
+          type: 'number',
+          value: 0.3
+        }
+      },
+      extensions: {
+        'org.lukasoppermann.figmaDesignTokens': {
+          exportKey: 'opacity'
+        }
+      }
+    }
+    ])
+  })
+})

--- a/tests/unit/getTokenNames.test.ts
+++ b/tests/unit/getTokenNames.test.ts
@@ -107,7 +107,8 @@ describe("getTokenNodes", () => {
                   }
                 }
               }
-            }]
+            }],
+            opacity: 0
           }
         ])
       },
@@ -142,7 +143,8 @@ describe("getTokenNodes", () => {
             paddingTop: 20,
             paddingRight: 20,
             paddingBottom: 20,
-            paddingLeft: 20
+            paddingLeft: 20,
+            opacity: 0.3
           }
         ])
       },
@@ -181,7 +183,7 @@ describe("getTokenNodes", () => {
         paddingRight: 0,
         paddingBottom: 0,
         paddingLeft: 0,
-        opacity: undefined
+        opacity: 1
       },
       {
         name: '10',
@@ -223,7 +225,7 @@ describe("getTokenNodes", () => {
         paddingRight: 0,
         paddingBottom: 0,
         paddingLeft: 0,
-        opacity: undefined
+        opacity: 0
       },
       {
         name: '20',
@@ -249,7 +251,7 @@ describe("getTokenNodes", () => {
         paddingRight: 20,
         paddingBottom: 20,
         paddingLeft: 20,
-        opacity: undefined
+        opacity: 0.3
       }
     ])
   })

--- a/tests/unit/getTokenNames.test.ts
+++ b/tests/unit/getTokenNames.test.ts
@@ -180,7 +180,8 @@ describe("getTokenNodes", () => {
         paddingTop: 0,
         paddingRight: 0,
         paddingBottom: 0,
-        paddingLeft: 0
+        paddingLeft: 0,
+        opacity: undefined
       },
       {
         name: '10',
@@ -221,7 +222,8 @@ describe("getTokenNodes", () => {
         paddingTop: 0,
         paddingRight: 0,
         paddingBottom: 0,
-        paddingLeft: 0
+        paddingLeft: 0,
+        opacity: undefined
       },
       {
         name: '20',
@@ -246,7 +248,8 @@ describe("getTokenNodes", () => {
         paddingTop: 20,
         paddingRight: 20,
         paddingBottom: 20,
-        paddingLeft: 20
+        paddingLeft: 20,
+        opacity: undefined
       }
     ])
   })

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -46,7 +46,8 @@ const baseSettings = {
     radius: 'radius, radii',
     size: 'size',
     spacing: 'spacing',
-    motion: 'motion'
+    motion: 'motion',
+    opacity: 'opacity'
   },
   exports: {
     color: true,
@@ -60,7 +61,8 @@ const baseSettings = {
     radius: true,
     size: true,
     spacing: true,
-    motion: true
+    motion: true,
+    opacity: true
   }
 }
 describe('Testing setSettings', () => {

--- a/tests/unit/transformer.originalFormatTransformer.test.ts
+++ b/tests/unit/transformer.originalFormatTransformer.test.ts
@@ -20,4 +20,5 @@ describe('originalFormatTransfomer', () => {
   test('effect token', () => expect(transformer(extractedFigmaTokens.effect)).toStrictEqual(transformedOriginalTokens.effect))
   test('multi effect token', () => expect(transformer(extractedFigmaTokens.multiEffect)).toStrictEqual(transformedOriginalTokens.multiEffect))
   test('motion token', () => expect(transformer(extractedFigmaTokens.motion)).toStrictEqual(transformedOriginalTokens.motion))
+  test('opacity token', () => expect(transformer(extractedFigmaTokens.opacity)).toStrictEqual(transformedOriginalTokens.opacity))
 })

--- a/tests/unit/transformer.standardTransformer.test.ts
+++ b/tests/unit/transformer.standardTransformer.test.ts
@@ -21,4 +21,5 @@ describe('standard Transfomer', () => {
   test('effect token', () => expect(transformer(extractedFigmaTokens.effect)).toStrictEqual(transformedStandardTokens.effect))
   test('multi effect token', () => expect(transformer(extractedFigmaTokens.multiEffect)).toStrictEqual(transformedStandardTokens.multiEffect))
   test('motion token', () => expect(transformer(extractedFigmaTokens.motion)).toStrictEqual(transformedStandardTokens.motion))
+  test('motion token', () => expect(transformer(extractedFigmaTokens.opacity)).toStrictEqual(transformedStandardTokens.opacity))
 })

--- a/tests/unit/transformer.standardTransformer.test.ts
+++ b/tests/unit/transformer.standardTransformer.test.ts
@@ -21,5 +21,5 @@ describe('standard Transfomer', () => {
   test('effect token', () => expect(transformer(extractedFigmaTokens.effect)).toStrictEqual(transformedStandardTokens.effect))
   test('multi effect token', () => expect(transformer(extractedFigmaTokens.multiEffect)).toStrictEqual(transformedStandardTokens.multiEffect))
   test('motion token', () => expect(transformer(extractedFigmaTokens.motion)).toStrictEqual(transformedStandardTokens.motion))
-  test('motion token', () => expect(transformer(extractedFigmaTokens.opacity)).toStrictEqual(transformedStandardTokens.opacity))
+  test('opacity token', () => expect(transformer(extractedFigmaTokens.opacity)).toStrictEqual(transformedStandardTokens.opacity))
 })

--- a/types/propertyObject.d.ts
+++ b/types/propertyObject.d.ts
@@ -318,3 +318,12 @@ export type effectPropertyInterface = propertyObject & {
     }
   }[]
 }
+
+export type opacityPropertyInterface = propertyObject & {
+  values: {
+    opacity: {
+      value: number,
+      type: PropertyType
+    }
+  }
+}

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -37,7 +37,8 @@ export type Settings = {
     radius: string,
     size: string,
     spacing: string,
-    motion: string
+    motion: string,
+    opacity: string
   }
   exports: {
     color: boolean,
@@ -51,6 +52,7 @@ export type Settings = {
     radius: boolean,
     size: boolean,
     spacing: boolean,
-    motion: boolean
+    motion: boolean,
+    opacity: boolean
   }
 }

--- a/types/standardToken.d.ts
+++ b/types/standardToken.d.ts
@@ -5,7 +5,8 @@ export type customTokenTypes = 'custom-spacing' |
 'custom-transition' |
 'custom-stroke' |
 'custom-grid' |
-'custom-gradient'
+'custom-gradient' |
+'custom-opacity'
 
 export type StandardTokenTypes = 'string' |
 'number' |

--- a/types/tokenCategory.d.ts
+++ b/types/tokenCategory.d.ts
@@ -10,4 +10,5 @@ export type tokenCategoryType =
   'radius' |
   'size' |
   'spacing' |
-  'motion'
+  'motion' |
+  'opacity'

--- a/types/tokenExportKey.d.ts
+++ b/types/tokenExportKey.d.ts
@@ -10,4 +10,5 @@ export type tokenExportKeyType =
   'radius' |
   'size' |
   'spacing' |
-  'motion'
+  'motion' |
+  'opacity'

--- a/types/tokenNodeTypes.d.ts
+++ b/types/tokenNodeTypes.d.ts
@@ -24,6 +24,7 @@ export type customTokenNode = {
   paddingRight?: number,
   paddingBottom?: number,
   paddingLeft?: number,
+  opacity?: number
 }
 
 export type nodeWithNodeTransition = customTokenNode & {


### PR DESCRIPTION
This PR adds support for adding opacities as tokens. It is a rare use-case, but as always, it happens that my company requires it to be covered.

In our case, we have several UI elements that use opacity (ie. disabled inputs, "unselected" cards etc.), and depending on the applied theme the value varies.

Therefore, having the ability to define these custom opacities in figma, and have everything generated with `style-dictionary` to be consumed by the engineering team would help enormously.