### PR TITLE
pre-fix for motion

### DIFF
--- a/tests/unit/exportRawTokenArray.test.ts
+++ b/tests/unit/exportRawTokenArray.test.ts
@@ -211,6 +211,8 @@ describe('exportRawTokenArray', () => {
     // @ts-ignore
     extractBreakpoints.mockImplementation(() => [])
     // @ts-ignore
+    extractOpacities.mockImplementation(() => [])
+    // @ts-ignore
     expect(exportRawTokenArray('', { ...defaultSettings, ...{ prefix: { color: undefined } } })).toStrictEqual([])
   })
 })

--- a/types/propertyObject.d.ts
+++ b/types/propertyObject.d.ts
@@ -173,6 +173,14 @@ export type easingFunctionPropertyInterface = {
   }
 }
 
+export type easingPropertyInterface = {
+  easing: {
+    value: string,
+    type: PropertyType
+  },
+  easingFunction: easingFunctionPropertyInterface
+}
+
 export type motionPropertyInterface = propertyObject & {
   values: {
     transitionType: {


### PR DESCRIPTION
This disable export for spring animations as a temporary fix to avoid a bug that hinders export.

Implementing export for spring is coming up next.