### PR TITLE
fix: don't add mode level if only one mode is present

### DIFF
--- a/src/utilities/getVariables.ts
+++ b/src/utilities/getVariables.ts
@@ -64,8 +64,8 @@ const extractVariable = (variable, value) => {
 
 const processAliasModes = (variables) => {
   return variables.reduce((collector, variable) => {
-    // nothing needs to be done to variables that have no alias modes
-    if (!variable.aliasModes) {
+    // nothing needs to be done to variables that have no alias modes, or only one mode
+    if (!variable.aliasModes || variable.aliasModes.length < 2) {
       collector.push(variable)
 
       return collector
@@ -105,10 +105,13 @@ export const getVariables = (figma: PluginAPI, settings: Settings) => {
     const { name: collection, modes } = collections[variableCollectionId]
     // return each mode value as a separate variable
     return Object.entries(variable.valuesByMode).map(([id, value]) => {
+      // Only add mode if there's more than one
+      let addMode = settings.modeReference && modes.length > 1
       return {
         ...extractVariable(variable, value),
         // name is contstructed from collection, mode and variable name
-        name: settings.modeReference ? `${collection}/${modes.find(({ modeId }) => modeId === id).name}/${variable.name}` : `${collection}/${variable.name}`,
+
+        name: addMode ? `${collection}/${modes.find(({ modeId }) => modeId === id).name}/${variable.name}` : `${collection}/${variable.name}`,
         // add mnetadata to extensions
         extensions: {
           [config.key.extensionPluginData]: {


### PR DESCRIPTION
This PR is primarily for discussion. It addresses bugs I've been seeing with the most recent version of the plugin. I was seeing similar behavior as https://github.com/lukasoppermann/design-tokens/issues/271 , https://github.com/lukasoppermann/design-tokens/issues/273 and https://github.com/lukasoppermann/design-tokens/issues/274.  

In my case, our token variables had a collection of `primitives` with a single mode, and then a `colors` collection with 2 modes whose values all referred back to primitive values. The desired output would look like so:
```
  "primitives": {
    "color": {
      "white": {
        "50": {
          "type": "color",
          "value": "#ffffffff",
          "blendMode": "normal"
        },
      "black": {
        "50": {
          "type": "color",
          "value": "#00000000",
          "blendMode": "normal"
        },
      ...
      }
    }
  "colors": {
    "dark": {
      "text": {
        "primary": {
          "type": "color",
          "value": "{primitives.color.white.50}"
        }
      }
    },
    "light": {
      "text": {
        "primary": {
          "type": "color",
          "value": "{primitives.color.black.60}"
        }
      }
    },
```

What came out was very confusing - with a "Value" level in `primitives`, and the `colors` had a mix of values grouped into a top level  `value` object and others grouped into top level `light` and `dark` objects. I couldn't figure out any rhyme or reason to it.

The changes here disable adding the mode level if there's only one mode, and with this change, I get what I want in my tokens, but maybe there's a good reason not to do this - I'm not sure.  I think it may have already been discussed around https://github.com/lukasoppermann/design-tokens/pull/258.

