### PR TITLE
Fix content-security-policy blocking for self-hosted instances(#302)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,15 +6,8 @@
   "ui": "dist/ui.html",
   "editorType": ["figma"],
   "networkAccess": {
-    "allowedDomains": [
-      "https://github.com",
-      "https://bitbucket.org/",
-      "https://gitlab.com/",
-      "https://rsms.me",
-      "https://*.bitbucket.org/",
-      "https://*.gitlab.com/",
-      "https://*.github.com"
-    ]
+    "allowedDomains": ["*"],
+    "reasoning": "Wildcard is needed to use the plugin with companies' self-hosted CI instance"
   },
   "menu": [
     { "name": "Export Design Token File", "command": "export" },


### PR DESCRIPTION
Hello! Thank you for your work on the plugin!

This PR contains little fix for networkAccess and allows to use self-hosted instances of GitLab/GitHub/etc.

Fixes: #302, https://github.com/lukasoppermann/design-tokens/issues/295#issuecomment-1863944373  